### PR TITLE
Fix HOMING_SINGLE_AXIS_COMMANDS bug

### DIFF
--- a/grbl/system.c
+++ b/grbl/system.c
@@ -178,13 +178,13 @@ uint8_t system_execute_line(char *line)
                 case 'Y': mc_homing_cycle(HOMING_CYCLE_Y); break;
                 case 'Z': mc_homing_cycle(HOMING_CYCLE_Z); break;
               #if N_AXIS > 3
-                case AXIS_4_NAME: mc_homing_cycle(HOMING_CYCLE_4); break;
+                case AXIS_4_NAME: mc_homing_cycle(HOMING_CYCLE_A); break;
               #endif
               #if N_AXIS > 4
-                case AXIS_5_NAME: mc_homing_cycle(HOMING_CYCLE_5); break;
+                case AXIS_5_NAME: mc_homing_cycle(HOMING_CYCLE_B); break;
               #endif
               #if N_AXIS > 5
-                case AXIS_6_NAME: mc_homing_cycle(HOMING_CYCLE_6); break;
+                case AXIS_6_NAME: mc_homing_cycle(HOMING_CYCLE_C); break;
               #endif
                 default: return(STATUS_INVALID_STATEMENT);
               }


### PR DESCRIPTION
In `motion_control.h`, the 4th 5th and 6th axis homing cycles are defined as  `HOMING_CYCLE_A/B/C`, but in `system.c` they were being referenced as `HOMING_CYCLE_1/2/3`

This lead to a compile time error when enabling the feature `HOMING_SINGLE_AXIS_COMMANDS`