### PR TITLE
Fix EEPROM checksum to not be lastchar or lastchar+1

### DIFF
--- a/grbl/eeprom.c
+++ b/grbl/eeprom.c
@@ -130,7 +130,7 @@ void eeprom_put_char( unsigned int addr, unsigned char new_value )
 void memcpy_to_eeprom_with_checksum(unsigned int destination, char *source, unsigned int size) {
   unsigned char checksum = 0;
   for(; size > 0; size--) { 
-    checksum = (checksum << 1) || (checksum >> 7);
+    checksum = (checksum << 1) | (checksum >> 7);
     checksum += *source;
     eeprom_put_char(destination++, *(source++)); 
   }
@@ -141,7 +141,7 @@ int memcpy_from_eeprom_with_checksum(char *destination, unsigned int source, uns
   unsigned char data, checksum = 0;
   for(; size > 0; size--) { 
     data = eeprom_get_char(source++);
-    checksum = (checksum << 1) || (checksum >> 7);
+    checksum = (checksum << 1) | (checksum >> 7);
     checksum += data;    
     *(destination++) = data; 
   }


### PR DESCRIPTION
Per https://github.com/gnea/grbl-Mega/issues/158 the logical OR in the code below discards most of the checksum information, resulting in the final chekcsum being either the last character, or the last character +1.

https://github.com/fra589/grbl-Mega-5X/blob/7a293a9ce03231f18a8e9d3011e1f0b145ba9644/grbl/eeprom.c#L130-L149


This fix brings the checksum in-line with grblHAL's implementation:  https://github.com/grblHAL/core/blob/3a84b58d301f04279268b4ef1045fd6bc0961be5/nuts_bolts.c#L267-L278

See also the discussion at https://github.com/grbl/grbl/issues/1249